### PR TITLE
docs: Fix 'type' in configuration example to have full module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The appender will use the Redis PUBLISH command to send the log event messages t
 ```javascript
 log4js.configure({
   appenders: {
-    redis: { type: 'redis', channel: 'logs' }
+    redis: { type: '@log4js-node/redis', channel: 'logs' }
   },
   categories: { default: { appenders: ['redis'], level: 'info' } }
 });


### PR DESCRIPTION
In log4js < 3.x, type could be 'redis' because it was a core appender.

With log4js 3.x+, one must specify the full module name.

Thanks!